### PR TITLE
Allow tests to fail to make the tests testing the library pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/describe.js
+++ b/describe.js
@@ -74,7 +74,7 @@
 
 	function runTest(fun, callback, options) {
 
-		var done, timer, errorExpected;
+		var done, timer, errorExpected, testFailExpected = false;
 
 		function respond(e) {
 			if (done) return;
@@ -85,6 +85,13 @@
 					e = null;
 				} else {
 					e = new Error("Expected error '"+errorExpected+"' but got "+e);
+				}
+			}
+			if (testFailExpected) {
+				if (e) {
+					e = null;
+				} else {
+					e = new Error("Expected test to fail");
 				}
 			}
 			callback(e);
@@ -100,6 +107,9 @@
 					options.getError = true;
 					errorExpected = b || a;
 					return expect(a, b, respond, options);
+				},
+				expectTestToFail: function() {
+					testFailExpected = true;
 				}
 			});
 		} catch (e) {

--- a/describe.js
+++ b/describe.js
@@ -94,7 +94,7 @@
 		try {
 			fun.call({
 				expect: function(a,b) {
-					return expect(a,b,respond,{});
+					return expect(a, b, respond, options);
 				},
 				expectError: function(a,b) {
 					options.getError = true;

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
 		"url":  "http://msteigerwalt.com"
 	},
 	"homepage": "http://github.com/yuffster/describe",
-	"main": "describe.js"
+	"main": "describe.js",
+	"scripts": {
+		"test": "node tests/run_tests.js"
+	}
 }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -81,10 +81,12 @@ describe("synchronous operations", {
 	},
 
 	'log error on exception (this should fail)': function() {
+		this.expectTestToFail();
 		throw new Error("intentional failure");
 	},
 
 	'failed expectation (this should fail)': function() {
+		this.expectTestToFail();
 		this.expect(false, true);
 	},
 
@@ -101,6 +103,7 @@ describe("asynchronous operations", {
 	},
 
 	'asynchronous timeout (this should fail)': function() {
+		this.expectTestToFail();
 		var my = this;
 		setTimeout(function() { my.expect(42); }, 1000);
 	}
@@ -110,6 +113,7 @@ describe("asynchronous operations", {
 describe("node error style", {
 
 	'asynchronous node-style error (this should fail)': function() {
+		this.expectTestToFail();
 		asyncNodeError(this.expect(true));
 	},
 
@@ -128,10 +132,12 @@ describe("promise callback style", {
 	},
 
 	'promises-style failure (this should fail)': function() {
+		this.expectTestToFail();
 		this.expect(failedPromise(2, 2), 4);
 	},
 
 	'promises-style timeout (this should fail)': function() {
+		this.expectTestToFail();
 		this.expect(promiseTimeout(), 42);
 	}
 
@@ -152,6 +158,7 @@ describe("custom timeout higher", {
 describe("custom lower timeout", {
 
 	'custom timeout failure (this should fail)': function() {
+		this.expectTestToFail();
 		(function(callback) {
 			setTimeout(function() {  callback(2); }, 2);
 		}(this.expect(2)));
@@ -162,7 +169,7 @@ describe("custom lower timeout", {
 describe("expections", {
 
 	"pending expectation fails (this should fail)": function() {
-		
+		this.expectTestToFail();
 	}
 
 });
@@ -252,11 +259,13 @@ describe('error expectations, Promises', {
 	},
 
 	"wrong error string returned (this should fail)": function() {
+		this.expectTestToFail();
 		this.expectError(failedPromiseString(), "out of cheese");
 	},
 
 
 	"wrong error object returned (this should fail)": function() {
+		this.expectTestToFail();
 		this.expectError(failedPromise(), "out of cheese");
 	}
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -252,7 +252,7 @@ describe('error expectations, Promises', {
 	},
 
 	"wrong error string returned (this should fail)": function() {
-		this.expectError(failedPromiseString(), "expected error");
+		this.expectError(failedPromiseString(), "out of cheese");
 	},
 
 


### PR DESCRIPTION
(other changes are gonna be rebased when PR is merged, just look at the latest commit)

Add a `this.expectTestToFail` to make a failing test pass (and the contrary).

A bit hacky but it works well, a better solution would be to run each tests directly without using the singleton by the library

EDIT: A problem I detected, if you've got an error outside the expects (like mispelling a variable name), the test is gonna pass silently. Maybe should restrict the failing to happen inside the expects.
