### PR TITLE
Allow creation of describe instances and use it to test failing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ call this.
 
 Gets the results and outputs them either to the DOM or the console.
 
+### describe.new
+
+Create a new independant instance of `describe`.
+
 ### Test Hooks
 
 Each test group supports beforeEach, afterEach, beforeAll, and afterAll as

--- a/describe.js
+++ b/describe.js
@@ -1,4 +1,4 @@
-(function(scope) {
+(function describeFactory(scope, returnInstance) {
 
 	var isModule = false;
 
@@ -41,7 +41,7 @@
 
 		if (data.passed!==data.total) output += "FAILED".color('red');
 		else output += "PASSED".color('green');
-		output += ": "+data.passed+"/"+data.total;
+		output += ": "+data.passed+" passed / "+data.total+" tests";
 
 		return output;
 
@@ -210,6 +210,15 @@
 			else outputConsole(data, options);
 		});
 	};
+
+	// allow to make other describe instances
+	describe.factory = function() {
+		return describeFactory(null, true);
+	};
+
+	if (returnInstance) {
+		return describe;
+	}
 
 	if (isModule) module.exports = describe;
 	else scope.describe = describe;

--- a/describe.js
+++ b/describe.js
@@ -1,4 +1,4 @@
-(function describeFactory(scope, returnInstance) {
+(function initialize(scope) {
 
 	var isModule = false;
 
@@ -212,11 +212,11 @@
 	};
 
 	// allow to make other describe instances
-	describe.factory = function() {
-		return describeFactory(null, true);
+	describe.new = function() {
+		return initialize();
 	};
 
-	if (returnInstance) {
+	if (!scope) {
 		return describe;
 	}
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -75,7 +75,7 @@ function asyncError(cb) {
 }
 
 function expectTest(test, cb, options) {
-	var describe2 = describe.factory();
+	var describe2 = describe.new();
 	describe2('test', { 'test': test }, options)
 	describe2.getResults(cb);
 };


### PR DESCRIPTION
New approach for #6, allow new instances of `describe` to be created and tested.
